### PR TITLE
When doing recon on a domain, TXT records are just as interesting as A Records, IMO

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,20 +5,24 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/evilsocket/brutemachine"
-	"github.com/bobesa/go-domain-util/domainutil"
-	"github.com/fatih/color"
 	"net"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/bobesa/go-domain-util/domainutil"
+	"github.com/evilsocket/brutemachine"
+	"github.com/fatih/color"
 )
 
-const Version = "1.0.0"
+//Version is version
+const Version = "1.0.1"
 
+// Result to show what we've found
 type Result struct {
 	hostname string
-	addrs []string
+	addrs    []string
+	txts     []string
 }
 
 var (
@@ -32,37 +36,55 @@ var (
 	base      = flag.String("domain", "", "Base domain to start enumeration from.")
 	wordlist  = flag.String("wordlist", "names.txt", "Wordlist file to use for enumeration.")
 	consumers = flag.Int("consumers", 8, "Number of concurrent consumers.")
+	searchtxt = flag.Bool("txt", false, "Search for TXT records")
 )
 
+// DoRequest actually handles the DNS lookups
 func DoRequest(sub string) interface{} {
 	hostname := fmt.Sprintf("%s.%s", sub, *base)
+	thisresult := Result{}
 	if addrs, err := net.LookupHost(hostname); err == nil {
-		return Result{ hostname: hostname, addrs: addrs }
+		thisresult.hostname = hostname
+		thisresult.addrs = addrs
 	}
-	
-	return nil
+	if *searchtxt {
+		if txts, err := net.LookupTXT(hostname); err == nil {
+			thisresult.hostname = hostname
+			thisresult.txts = txts
+		}
+	}
+
+	if thisresult.hostname == "" {
+		return nil
+	}
+	return thisresult
 }
 
+// OnResult prints out the results of a lookup
 func OnResult(res interface{}) {
 	result, ok := res.(Result)
 	if !ok {
-		r.Printf( "Error while converting result.\n" )
+		r.Printf("Error while converting result.\n")
 		return
 	}
 
-	g.Printf( "%25s", result.hostname )
-	fmt.Printf( " : %v\n", result.addrs )
+	g.Printf("%25s", result.hostname)
+	fmt.Printf(" : %v", result.addrs)
+	if *searchtxt {
+		fmt.Printf(" : %v", result.txts)
+	}
+	fmt.Printf("\n")
 }
 
 func main() {
 	setup()
 
-	m = brutemachine.New( *consumers, *wordlist, DoRequest, OnResult)
-    if err := m.Start(); err != nil {
-        panic(err)
-    }
+	m = brutemachine.New(*consumers, *wordlist, DoRequest, OnResult)
+	if err := m.Start(); err != nil {
+		panic(err)
+	}
 
-    m.Wait()
+	m.Wait()
 
 	g.Println("\nDONE")
 
@@ -72,12 +94,12 @@ func main() {
 // Do some initialization.
 func setup() {
 	r.Printf("dnssearch")
-	fmt.Printf( " v%s\n\n", Version )
+	fmt.Printf(" v%s\n\n", Version)
 
 	flag.Parse()
 
 	if *base = domainutil.Domain(*base); *base == "" {
-		fmt.Println( "Invalid or empty domain specified." )
+		fmt.Println("Invalid or empty domain specified.")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -103,4 +125,3 @@ func printStats() {
 	fmt.Println("Time     :", m.Stats.Total.Seconds(), "s")
 	fmt.Println("Req/s    :", m.Stats.Eps)
 }
-


### PR DESCRIPTION

I am not a gopher, but I did wish that this tool would look up TXT records in addition to A records, so I added that functionality. 

I'm not sure if this is ideomatic go, or not.. but here's a PR that adds the functionality in the subject. 

My linter was mildly upset with lacking comments, and a little bit of the indentation, and the source was changed to please my linter. 