### PR TITLE
Changed CMD to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM alpine:latest
 WORKDIR /app
 COPY --from=build-stage /go/src/github.com/evilsocket/dnssearch/dnssearch /app
 COPY names.txt /app
-CMD ["/app/dnssearch"]
+ENTRYPOINT ["/app/dnssearch"]


### PR DESCRIPTION
Changed to ENTRYPOINT instead of CMD. After build and run, with CMD, below is what occurs:

docker run -it --rm dnssearch -domain google.com
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: "-domain": executable file not found in $PATH".

When changed to 'ENTRYPOINT ["/app/dnssearch"]' the below commands work:
docker run -it --rm dnssearch -domain google.com
docker run -it --rm dnssearch -domain google.com -consumers 10