### PR TITLE
[FIX] Do not parse TLD to allow running thought X.TLD.COM just as well

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/bobesa/go-domain-util/domainutil"
 	"github.com/evilsocket/brutemachine"
 	"github.com/fatih/color"
 )
@@ -114,7 +113,7 @@ func setup() {
 
 	flag.Parse()
 
-	if *base = domainutil.Domain(*base); *base == "" {
+	if *base == "" {
 		fmt.Println("Invalid or empty domain specified.")
 		flag.Usage()
 		os.Exit(1)


### PR DESCRIPTION
Issue:
./dnssearch -domain env.tld.com

Will search through *tld.com* instead of *env.tld.com*

As a user of the lib, I really felt like I want to be protected from empty string, but beyond that, I want to have full control on the domain pattern I want to run my search over.

