### PR TITLE
[FIX] Do not parse TLD to allow running thought X.TLD.COM just as well

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,12 +34,13 @@ var (
 	r = color.New(color.FgRed)
 	b = color.New(color.FgBlue)
 
-	base        = flag.String("domain", "", "Base domain to start enumeration from.")
-	wordlist    = flag.String("wordlist", "names.txt", "Wordlist file to use for enumeration.")
-	consumers   = flag.Int("consumers", 8, "Number of concurrent consumers.")
-	searchtxt   = flag.Bool("txt", false, "Search for TXT records")
-	searchcname = flag.Bool("cname", false, "Show CNAME results")
-	searcha     = flag.Bool("a", true, "Show A results")
+	base         = flag.String("domain", "", "Base domain to start enumeration from.")
+	wordlist     = flag.String("wordlist", "names.txt", "Wordlist file to use for enumeration.")
+	consumers    = flag.Int("consumers", 8, "Number of concurrent consumers.")
+	searchtxt    = flag.Bool("txt", false, "Search for TXT records")
+	searchcname  = flag.Bool("cname", false, "Show CNAME results")
+	searcha      = flag.Bool("a", true, "Show A results")
+	forceTld     = flag.Bool("force-tld", true, "Extract top level from provided domain")
 )
 
 // DoRequest actually handles the DNS lookups
@@ -114,10 +115,14 @@ func setup() {
 
 	flag.Parse()
 
-	if *base = domainutil.Domain(*base); *base == "" {
+	if  *base == "" {
 		fmt.Println("Invalid or empty domain specified.")
 		flag.Usage()
 		os.Exit(1)
+	}
+
+	if *forceTld {
+		*base = domainutil.Domain(*base);
 	}
 
 	// if interrupted, print statistics and exit


### PR DESCRIPTION
Issue:
./dnssearch -domain env.tld.com

Will search through tld.com instead of env.tld.com

As a user of the lib, I really felt like I want to be protected from empty string, but beyond that, I want to have full control on the domain pattern I want to run my search over.

Add now as a command line (force-tld), defaults to current behavior, so not breaking API.

Worth noting that I fully understand original intention to to search subdomain over TLD, but I am not sure I see the value in forcing this, with the new flag, it's up to the user to have a more powerful tool with out the stripping decision imposed on him.